### PR TITLE
Minor bug fixes

### DIFF
--- a/cg3/viewer.pri
+++ b/cg3/viewer.pri
@@ -25,6 +25,10 @@ unix:!macx{
     exists (/usr/lib/x86_64-linux-gnu/libQGLViewer-qt5.so) {
         LIBS += -lQGLViewer-qt5
     }
+    # Default installation folder if compiled from source
+    exists (/usr/local/lib/libQGLViewer-qt5.so) {
+        LIBS += -lQGLViewer-qt5
+    }
     LIBS += -lstdc++fs
 }
 

--- a/cg3/viewer/interfaces/drawable_object.h
+++ b/cg3/viewer/interfaces/drawable_object.h
@@ -12,8 +12,8 @@
 #include <float.h>
 #include <cg3/geometry/point3.h>
 
-#ifdef CG3_VIEWER_DEFINED
 namespace cg3 {
+#ifdef CG3_VIEWER_DEFINED
 namespace viewer {
 class GLCanvas;
 }


### PR DESCRIPTION
This commit adds the default path for libQGLViewer when it's built from sources, and fix a wrong conditional compilation directive.